### PR TITLE
[340210] [PCCP 기출문제] 4번 / 수식 복원하기 (zizonyoungjun)

### DIFF
--- a/youngjun/수식_복원하기.py
+++ b/youngjun/수식_복원하기.py
@@ -27,7 +27,7 @@ def get_result_in_base(expr, base):
     b_val = int(b, base)
     if op == '+':
         return convert_to_base(a_val + b_val, base)
-    else:  # op == '-'
+    else: 
         return convert_to_base(a_val - b_val, base)
 
 def solution(expressions):


### PR DESCRIPTION
## 문제 풀이

- 결과까지 주어진 수식과 결과가 누락된 수식을(`questions`,`knowns`)을 분리하고, 입력된 수식에서 사용된 숫자의 가장 큰 자릿수를 찾아서 가능한 진법의 시작점을 설정했습니다.
- 각 진법(`base`)에서 `knowns`의 모든 수식이 성립하는지 확인하여 유효한 진법만 `possible_bases`에 추가했습니다.
- 이어서 각 진법에서 X의 값을 계산하여 결과를 results에 저장하되, 숫자 변환이 실패하거나 계산할 수 없는 경우(`ValueError`)에는 해당 진법을 건너뛰도록 했습니다.
- 이로 도출된 `results`의 크기를 확인하여 결과를 결정합니다. 가능한 결과가 하나라면(`len(results) == 1`)  해당 값으로 수식을 완성하고, 여러 결과가 나오면 ?로 처리하도록 했습니다.
## 문제 링크

- [문제 링크](https://school.programmers.co.kr/learn/courses/30/lessons/340210)
