### PR TITLE
[30805] 사전 순 최대 공통 부분 수열 (cjeongmin)

### DIFF
--- a/cjeongmin/사전-순-최대-공통-부분-수열.js
+++ b/cjeongmin/사전-순-최대-공통-부분-수열.js
@@ -1,0 +1,56 @@
+const fs = require('fs');
+const input = fs.readFileSync(0).toString().trim().split('\n');
+
+const N = Number(input[0]);
+const A = input[1].split(' ').map(Number);
+const M = Number(input[2]);
+const B = input[3].split(' ').map(Number);
+
+function preprocess(arr) {
+  const positions = new Map();
+  for (let i = 0; i < arr.length; i++) {
+    const num = arr[i];
+    if (!positions.has(num)) {
+      positions.set(num, []);
+    }
+    positions.get(num).push(i);
+  }
+  return positions;
+}
+
+const posA = preprocess(A);
+const posB = preprocess(B);
+
+function findNextIndex(positionsMap, num, minIndex) {
+  if (!positionsMap.has(num)) {
+    return null;
+  }
+  return positionsMap.get(num).find((idx) => idx >= minIndex);
+}
+
+function findLCS(currentAIdx, currentBIdx) {
+  if (currentAIdx >= N || currentBIdx >= M) {
+    return [];
+  }
+
+  for (let val = 100; val >= 1; val--) {
+    const nextAIdx = findNextIndex(posA, val, currentAIdx);
+
+    if (nextAIdx != null) {
+      const nextBIdx = findNextIndex(posB, val, currentBIdx);
+
+      if (nextBIdx != null) {
+        const sub = findLCS(nextAIdx + 1, nextBIdx + 1);
+        return [val, ...sub];
+      }
+    }
+  }
+  return [];
+}
+
+const result = findLCS(0, 0);
+
+console.log(result.length);
+if (result.length > 0) {
+  console.log(result.join(' '));
+}


### PR DESCRIPTION
## 문제 풀이

- 사전 순 비교의 특성상 두 수열은 가장 앞자리부터 비교하여 처음으로 다른 숫자가 나오는 지점에서 더 큰 숫자를 가진 쪽이 사전 순으로 더 큼
  - 따라서 수열의 첫 번째 원소를 만들 때 현재 선택 가능한 숫자 중 가장 큰 값을 선택하는 것이 유리함
  - 만약 이보다 작은 숫자를 선택한다면, 그 어떤 나머지 부분 수열을 이어붙이더라도 사전 순으로 더 큰 수열을 만들 수 없음
- 따라서 100부터 1까지 숫자를 탐색하며 두 수열에서 유효한 범위 내에서 공통으로 발견되는 가장 큰 숫자를 현재 부분 수열의 원소로 즉시 선택
- 각 숫자가 배열 내에 등장하는 인덱스를 리스트로 미리 계산하여 저장하고 특정 인덱스 이후로 발견되는 인덱스를 통해서 두 수열에서 특정 값이 존재하는지 판단
- 배열 끝까지 순회하며 반복

## 문제 링크

- [문제 링크](https://www.acmicpc.net/problem/30805)
