### PR TITLE
[20056] 마법사 상어와 파이어볼 (chichoc)

### DIFF
--- a/chichoc/20056_마법사 상어와 파이어볼.js
+++ b/chichoc/20056_마법사 상어와 파이어볼.js
@@ -1,0 +1,53 @@
+const inputs = require('fs').readFileSync(0).toString().trim().split('\n');
+const [N, M, K] = inputs[0].split(' ').map(Number);
+const balls = inputs.slice(1).map((ball) => ball.split(' ').map(Number));
+const dirs = [
+  [-1, 0],
+  [-1, 1],
+  [0, 1],
+  [1, 1],
+  [1, 0],
+  [1, -1],
+  [0, -1],
+  [-1, -1]
+];
+
+for (let turn = 0; turn < K; turn++) {
+  const board = Array.from({ length: N }, () => Array.from({ length: N }, () => []));
+  for (const [r, c, m, s, d] of balls) {
+    const nr = (r + ((dirs[d][0] * s) % N) + N * 1000) % N;
+    const nc = (c + ((dirs[d][1] * s) % N) + N * 1000) % N;
+    board[nr][nc].push([nr, nc, m, s, d]);
+  }
+
+  balls.length = 0;
+  for (let i = 0; i < N; i++) {
+    for (let j = 0; j < N; j++) {
+      const cell = board[i][j];
+      if (cell.length === 0) continue;
+      if (cell.length === 1) {
+        balls.push(cell[0]);
+      } else {
+        let sumM = 0,
+          sumS = 0,
+          allEven = true,
+          allOdd = true;
+        for (const [r, c, m, s, d] of cell) {
+          sumM += m;
+          sumS += s;
+          if (d % 2 === 0) allOdd = false;
+          else allEven = false;
+        }
+        const nm = Math.floor(sumM / 5);
+        if (nm === 0) continue;
+        const ns = Math.floor(sumS / cell.length);
+        const nds = allEven || allOdd ? [0, 2, 4, 6] : [1, 3, 5, 7];
+        for (const nd of nds) {
+          balls.push([i, j, nm, ns, nd]);
+        }
+      }
+    }
+  }
+}
+
+console.log(balls.reduce((sumM, ball) => sumM + ball[2], 0));


### PR DESCRIPTION
## 문제 풀이

- 빡구현
- 예전에 풀었던 문제인데, 문제 내용만 낯익고 풀이는 기억나지 않았다
- 현재 파이어볼과 나누어진 파이어볼을 하나의 큐에 저장할까 싶었지만, 5가지 정보가 이미 헷갈려서 이차원 배열에 저장했다
- 그랬더니 어마어마한 공간복잡도,,,(전보다 시간은 줄었지만 메모리 2배 가량 사용)
   하나의 큐에 저장하는 대신 이동 횟수 기준 값을 추가로 저장해 분류하면 어떨까 싶음

## 문제 링크

- [문제 링크](https://www.acmicpc.net/problem/20056)
